### PR TITLE
Require Docker instead of Vagrant and VirtualBox

### DIFF
--- a/cpp-linux/README.md
+++ b/cpp-linux/README.md
@@ -22,8 +22,7 @@
 ## Requirements
 
   * Ruby
-  * Vagrant
-  * VirtualBox
+  * Docker
   * Tools to build tar.gz for Apache Arrow C++ and GLib
 
 ## How to build .deb packages


### PR DESCRIPTION
I think this change should be in 3fb4e5ed220f052fa9d818ddd8f6276a6719f09a